### PR TITLE
feat: Print usage information

### DIFF
--- a/code/src/help.rs
+++ b/code/src/help.rs
@@ -1,0 +1,30 @@
+use std::io::Write;
+
+const USAGE_TEXT: &str = "Usage:
+    mutter-display-presets [action] [flags...]
+
+ACTIONS:
+    help - display usage info
+
+FLAGS:
+";
+
+pub fn print_usage<W: Write>(writer: &mut W) -> std::io::Result<()> {
+    writer.write_all(USAGE_TEXT.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_print_usage_generates_expected_output() {
+        let mut buffer: Vec<u8> = Vec::new();
+
+        let result = print_usage(&mut buffer);
+
+        assert!(!result.is_err());
+        assert_eq!(buffer.as_slice(), USAGE_TEXT.as_bytes());
+    }
+
+}

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -1,2 +1,5 @@
+mod help;
+
 fn main() {
+    help::print_usage(&mut std::io::stdout()).expect("Unable to print usage");
 }


### PR DESCRIPTION
When program starts without arguments, usage information is printed to the standard output.