### PR TITLE
feat: Addded functionality to rename presets

### DIFF
--- a/code/src/model.rs
+++ b/code/src/model.rs
@@ -9,11 +9,9 @@ pub struct Configuration {
 }
 
 impl Configuration {
-
     pub fn get_preset(&self, name: &str) -> Option<&Preset> {
-        self.presets.iter().find(|p|p.name.as_str() == name)
+        self.presets.iter().find(|p| p.name.as_str() == name)
     }
-
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -57,12 +55,12 @@ pub struct Monitor {
 }
 
 impl Monitor {
-
     pub fn get_current_mode_id(&self) -> Option<&String> {
-        self.modes.iter().find(|m| { m.properties.get("is-current").is_some_and(|v| { v == "1" }) })
-            .map(|cur_md| { &cur_md.id })
+        self.modes
+            .iter()
+            .find(|m| m.properties.get("is-current").is_some_and(|v| v == "1"))
+            .map(|cur_md| &cur_md.id)
     }
-
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -87,8 +85,8 @@ mod tests {
                 serial,
                 monitors: vec![],
                 logical_monitors: vec![],
-                properties: Props::new()
-            }
+                properties: Props::new(),
+            },
         }
     }
 
@@ -100,8 +98,8 @@ mod tests {
         let conf = Configuration {
             presets: vec![
                 generate_preset_with_name("Preset1", 1),
-                generate_preset_with_name("Preset2", 2)
-            ]
+                generate_preset_with_name("Preset2", 2),
+            ],
         };
 
         assert_eq!(&preset1, conf.get_preset("Preset1").unwrap());
@@ -126,7 +124,7 @@ mod tests {
                     refresh_rate: 0.0,
                     preferred_scale: 0.0,
                     supported_scales: vec![],
-                    properties: [("is-current".to_string(), "1".to_string())].into()
+                    properties: [("is-current".to_string(), "1".to_string())].into(),
                 },
                 Mode {
                     id: "2".to_string(),
@@ -135,13 +133,12 @@ mod tests {
                     refresh_rate: 0.0,
                     preferred_scale: 0.0,
                     supported_scales: vec![],
-                    properties: HashMap::new()
-                }
+                    properties: HashMap::new(),
+                },
             ],
-            properties: HashMap::new()
+            properties: HashMap::new(),
         };
 
         assert_eq!("1", monitor.get_current_mode_id().unwrap());
     }
-
 }

--- a/code/src/mutter.rs
+++ b/code/src/mutter.rs
@@ -127,27 +127,38 @@ pub fn get_current_state(
     Ok(DisplayConfigState::from(&current_state))
 }
 
-pub fn apply_monitors_config(serial: u32, persistent: bool, state: &DisplayConfigState, timeout: &Duration) -> Result<(), Box<dyn std::error::Error>> {
+pub fn apply_monitors_config(
+    serial: u32,
+    persistent: bool,
+    state: &DisplayConfigState,
+    timeout: &Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
     let conn = Connection::new_session()?;
     let proxy: Proxy<_> = conn.with_proxy(DESTINATION, PATH, timeout.clone());
 
     let method = if persistent { 2 } else { 1 };
-    let mut logical_monitors: Vec<(i32, i32, f64, u32, bool, Vec<(&str, &str, PropMap)>)> = Vec::new();
+    let mut logical_monitors: Vec<(i32, i32, f64, u32, bool, Vec<(&str, &str, PropMap)>)> =
+        Vec::new();
 
     for lm in &state.logical_monitors {
         let mut modes: Vec<(&str, &str, PropMap)> = Vec::new();
 
-        let connectors: Vec<&String> = lm.monitors.iter()
-            .map(|m| { &m.connector })
-            .collect();
+        let connectors: Vec<&String> = lm.monitors.iter().map(|m| &m.connector).collect();
 
         for connector in connectors {
-            if let Some(monitor) = state.monitors.iter().find(|m| m.monitor_info.connector == *connector) {
+            if let Some(monitor) = state
+                .monitors
+                .iter()
+                .find(|m| m.monitor_info.connector == *connector)
+            {
                 if let Some(current_mode_id) = monitor.get_current_mode_id() {
-                    modes.push((connector.as_str(), &current_mode_id.as_str(), PropMap::new()));
+                    modes.push((
+                        connector.as_str(),
+                        &current_mode_id.as_str(),
+                        PropMap::new(),
+                    ));
                 }
             }
-
         }
 
         logical_monitors.push((lm.x, lm.y, lm.scale, lm.transform, lm.primary, modes));


### PR DESCRIPTION
Implemented subcommand 'rename' which takes 2 arguments - preset name and preset new name. The subcommand renames preset. If there is another preset with target name, user is able to override it using --force option.